### PR TITLE
Replace “smart” quotes with real quotes.

### DIFF
--- a/CentOS_6_Teeth_post.sh
+++ b/CentOS_6_Teeth_post.sh
@@ -90,7 +90,7 @@ EOF
 cat > /etc/sysconfig/autofsck << EOF
 AUTOFSCK_DEF_CHECK=yes
 PROMPT=no
-AUTOFSCK_OPT=“-y”
+AUTOFSCK_OPT="-y"
 AUTOFSCK_TIMEOUT=10
 EOF
 


### PR DESCRIPTION
Smart quotes do not play nice with config files.