### PR TITLE
fix ip6tables to permit ipv6-icmp correctly

### DIFF
--- a/CentOS_5.cfg
+++ b/CentOS_5.cfg
@@ -126,7 +126,7 @@ cat > /etc/sysconfig/ip6tables <<'EOF'
 :FORWARD ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
 -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
--A INPUT -p icmp -j ACCEPT
+-A INPUT -p ipv6-icmp -j ACCEPT
 -A INPUT -i lo -j ACCEPT
 -A INPUT -m conntrack --ctstate NEW -m tcp -p tcp --dport 22 -j ACCEPT
 -A INPUT -j REJECT --reject-with icmp6-adm-prohibited

--- a/CentOS_6.cfg
+++ b/CentOS_6.cfg
@@ -104,7 +104,7 @@ cat > /etc/sysconfig/ip6tables <<'EOF'
 :FORWARD ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
 -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
--A INPUT -p icmpv6 -j ACCEPT
+-A INPUT -p ipv6-icmp -j ACCEPT
 -A INPUT -i lo -j ACCEPT
 -A INPUT -m conntrack --ctstate NEW -m tcp -p tcp --dport 22 -j ACCEPT
 -A INPUT -j REJECT --reject-with icmp6-adm-prohibited

--- a/CentOS_6_PVHVM.cfg
+++ b/CentOS_6_PVHVM.cfg
@@ -112,7 +112,7 @@ cat > /etc/sysconfig/ip6tables <<'EOF'
 :FORWARD ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
 -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
--A INPUT -p icmpv6 -j ACCEPT
+-A INPUT -p ipv6-icmp -j ACCEPT
 -A INPUT -i lo -j ACCEPT
 -A INPUT -m conntrack --ctstate NEW -m tcp -p tcp --dport 22 -j ACCEPT
 -A INPUT -j REJECT --reject-with icmp6-adm-prohibited

--- a/CentOS_6_PVHVM_Hadoop_Ambari.cfg
+++ b/CentOS_6_PVHVM_Hadoop_Ambari.cfg
@@ -112,7 +112,7 @@ cat > /etc/sysconfig/ip6tables <<'EOF'
 :FORWARD ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
 -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
--A INPUT -p icmpv6 -j ACCEPT
+-A INPUT -p ipv6-icmp -j ACCEPT
 -A INPUT -i lo -j ACCEPT
 -A INPUT -m conntrack --ctstate NEW -m tcp -p tcp --dport 22 -j ACCEPT
 -A INPUT -j REJECT --reject-with icmp6-adm-prohibited

--- a/CentOS_7_PVHVM.cfg
+++ b/CentOS_7_PVHVM.cfg
@@ -137,7 +137,7 @@ cat > /etc/sysconfig/ip6tables <<'EOF'
 :FORWARD ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
 -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
--A INPUT -p icmp -j ACCEPT
+-A INPUT -p ipv6-icmp -j ACCEPT
 -A INPUT -i lo -j ACCEPT
 -A INPUT -m conntrack --ctstate NEW -m tcp -p tcp --dport 22 -j ACCEPT
 -A INPUT -j REJECT --reject-with icmp6-adm-prohibited

--- a/CentOS_7_PVHVM_NovaAgent2.cfg
+++ b/CentOS_7_PVHVM_NovaAgent2.cfg
@@ -137,7 +137,7 @@ cat > /etc/sysconfig/ip6tables <<'EOF'
 :FORWARD ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
 -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
--A INPUT -p icmp -j ACCEPT
+-A INPUT -p ipv6-icmp -j ACCEPT
 -A INPUT -i lo -j ACCEPT
 -A INPUT -m conntrack --ctstate NEW -m tcp -p tcp --dport 22 -j ACCEPT
 -A INPUT -j REJECT --reject-with icmp6-adm-prohibited

--- a/Red_Hat_Enterprise_Linux_5.cfg
+++ b/Red_Hat_Enterprise_Linux_5.cfg
@@ -118,7 +118,7 @@ cat > /etc/sysconfig/ip6tables <<'EOF'
 :FORWARD ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
 -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
--A INPUT -p icmp -j ACCEPT
+-A INPUT -p ipv6-icmp -j ACCEPT
 -A INPUT -i lo -j ACCEPT
 -A INPUT -m conntrack --ctstate NEW -m tcp -p tcp --dport 22 -j ACCEPT
 -A INPUT -j REJECT --reject-with icmp6-adm-prohibited

--- a/Red_Hat_Enterprise_Linux_6.cfg
+++ b/Red_Hat_Enterprise_Linux_6.cfg
@@ -103,7 +103,7 @@ cat > /etc/sysconfig/ip6tables <<'EOF'
 :FORWARD ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
 -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
--A INPUT -p icmpv6 -j ACCEPT
+-A INPUT -p ipv6-icmp -j ACCEPT
 -A INPUT -i lo -j ACCEPT
 -A INPUT -m conntrack --ctstate NEW -m tcp -p tcp --dport 22 -j ACCEPT
 -A INPUT -j REJECT --reject-with icmp6-adm-prohibited

--- a/Red_Hat_Enterprise_Linux_6_PVHVM.cfg
+++ b/Red_Hat_Enterprise_Linux_6_PVHVM.cfg
@@ -107,7 +107,7 @@ cat > /etc/sysconfig/ip6tables <<'EOF'
 :FORWARD ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
 -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
--A INPUT -p icmpv6 -j ACCEPT
+-A INPUT -p ipv6-icmp -j ACCEPT
 -A INPUT -i lo -j ACCEPT
 -A INPUT -m conntrack --ctstate NEW -m tcp -p tcp --dport 22 -j ACCEPT
 -A INPUT -j REJECT --reject-with icmp6-adm-prohibited

--- a/Red_Hat_Enterprise_Linux_7_PVHVM.cfg
+++ b/Red_Hat_Enterprise_Linux_7_PVHVM.cfg
@@ -129,7 +129,7 @@ cat > /etc/sysconfig/ip6tables <<'EOF'
 :FORWARD ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
 -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
--A INPUT -p icmp -j ACCEPT
+-A INPUT -p ipv6-icmp -j ACCEPT
 -A INPUT -i lo -j ACCEPT
 -A INPUT -m conntrack --ctstate NEW -m tcp -p tcp --dport 22 -j ACCEPT
 -A INPUT -j REJECT --reject-with icmp6-adm-prohibited

--- a/Scientific_Linux_6_PVHVM.cfg
+++ b/Scientific_Linux_6_PVHVM.cfg
@@ -106,7 +106,7 @@ cat > /etc/sysconfig/ip6tables <<'EOF'
 :FORWARD ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
 -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
--A INPUT -p icmpv6 -j ACCEPT
+-A INPUT -p ipv6-icmp -j ACCEPT
 -A INPUT -i lo -j ACCEPT
 -A INPUT -m conntrack --ctstate NEW -m tcp -p tcp --dport 22 -j ACCEPT
 -A INPUT -j REJECT --reject-with icmp6-adm-prohibited

--- a/Scientific_Linux_7_PVHVM.cfg
+++ b/Scientific_Linux_7_PVHVM.cfg
@@ -131,7 +131,7 @@ cat > /etc/sysconfig/ip6tables <<'EOF'
 :FORWARD ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
 -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
--A INPUT -p icmp -j ACCEPT
+-A INPUT -p ipv6-icmp -j ACCEPT
 -A INPUT -i lo -j ACCEPT
 -A INPUT -m conntrack --ctstate NEW -m tcp -p tcp --dport 22 -j ACCEPT
 -A INPUT -j REJECT --reject-with icmp6-adm-prohibited


### PR DESCRIPTION
Fix for inadvertently blocking ipv6-icmp in CentOS/RHEL images