### PR TITLE
Fix for log file truncation issues

### DIFF
--- a/CentOS_5.cfg
+++ b/CentOS_5.cfg
@@ -238,6 +238,6 @@ rm -f /root/.nano_history
 rm -f /root/.lesshst
 rm -f /root/.ssh/known_hosts
 rm -rf /tmp/tmp
-for k in $(find /var/log -type f); do echo > $k; done
+for k in $(find /var/log -type f); do truncate -s 0 $k; done
 for k in $(find /tmp -type f); do rm -f $k; done
 for k in $(find /root -type f \( ! -iname ".*" \)); do rm -f $k; done

--- a/CentOS_6.cfg
+++ b/CentOS_6.cfg
@@ -388,7 +388,7 @@ rm -f /root/.nano_history
 rm -f /root/.lesshst
 rm -f /root/.ssh/known_hosts
 rm -rf /tmp/tmp
-for k in $(find /var/log -type f); do echo > $k; done
+for k in $(find /var/log -type f); do truncate -s 0 $k; done
 for k in $(find /tmp -type f); do rm -f $k; done
 for k in $(find /root -type f \( ! -iname ".*" \)); do rm -f $k; done
 %end

--- a/CentOS_6_PVHVM.cfg
+++ b/CentOS_6_PVHVM.cfg
@@ -397,7 +397,7 @@ rm -f /root/.nano_history
 rm -f /root/.lesshst
 rm -f /root/.ssh/known_hosts
 rm -rf /tmp/tmp
-for k in $(find /var/log -type f); do echo > $k; done
+for k in $(find /var/log -type f); do truncate -s 0 $k; done
 for k in $(find /tmp -type f); do rm -f $k; done
 for k in $(find /root -type f \( ! -iname ".*" \)); do rm -f $k; done
 

--- a/CentOS_7_PVHVM.cfg
+++ b/CentOS_7_PVHVM.cfg
@@ -351,7 +351,8 @@ rm -f /etc/resolv.conf
 touch /etc/resolv.conf
 rm -f /etc/sysconfig/network-scripts/ifcfg-eth0
 rm -rf /var/var
-for k in $(find /var/log -type f); do echo > $k; done
+rm -rf /var/log/anaconda/
+for k in $(find /var/log -type f); do truncate -s 0 $k; done
 for k in $(find /tmp -type f); do rm -f $k; done
 # watch these lines, causing kick problems
 #for k in $(find /root -type f \ ( ! -iname ".*" \)); do rm -f $k; done

--- a/Red_Hat_Enterprise_Linux_6.cfg
+++ b/Red_Hat_Enterprise_Linux_6.cfg
@@ -402,7 +402,7 @@ rm -f /root/.nano_history
 rm -f /root/.lesshst
 rm -f /root/.ssh/known_hosts
 rm -rf /tmp/tmp
-for k in $(find /var/log -type f); do echo > $k; done
+for k in $(find /var/log -type f); do truncate -s 0 $k; done
 for k in $(find /tmp -type f); do rm -f $k; done
 for k in $(find /root -type f \( ! -iname ".*" \)); do rm -f $k; done
 

--- a/Red_Hat_Enterprise_Linux_6_PVHVM.cfg
+++ b/Red_Hat_Enterprise_Linux_6_PVHVM.cfg
@@ -407,7 +407,7 @@ rm -f /root/.nano_history
 rm -f /root/.lesshst
 rm -f /root/.ssh/known_hosts
 rm -rf /tmp/tmp
-for k in $(find /var/log -type f); do echo > $k; done
+for k in $(find /var/log -type f); do truncate -s 0 $k; done
 for k in $(find /tmp -type f); do rm -f $k; done
 for k in $(find /root -type f \( ! -iname ".*" \)); do rm -f $k; done
 

--- a/Red_Hat_Enterprise_Linux_7_PVHVM.cfg
+++ b/Red_Hat_Enterprise_Linux_7_PVHVM.cfg
@@ -337,7 +337,8 @@ rm -f /root/.nano_history
 rm -f /root/.lesshst
 rm -f /root/.ssh/known_hosts
 rm -rf /tmp/tmp
-for k in $(find /var/log -type f); do echo > $k; done
+rm -rf /var/log/anaconda/
+for k in $(find /var/log -type f); do truncate -s 0 $k; done
 for k in $(find /tmp -type f); do rm -f $k; done
 rm -f /etc/yum.repos.d/rhel-source.repo
 # watch these lines, causing kick problems


### PR DESCRIPTION
Instead of replacing the contents of the log files in /var/log with a newline (which creates problems with btmp, at the very least), we should truncate them in place.