### PR TITLE
Fixing network manager service in RHEL

### DIFF
--- a/CentOS_7_PVHVM.cfg
+++ b/CentOS_7_PVHVM.cfg
@@ -325,15 +325,13 @@ GRUB_DISABLE_LINUX_UUID="true"
 EOF
 grub2-mkconfig
 
-# fix dns
-echo "dns=none" >> /etc/NetworkManager/NetworkManager.conf
+# fix dns as NetworkManager conflicts with Nova-Agent
+/usr/bin/systemctl mask NetworkManager-wait-online.service
+/usr/bin/systemctl mask NetworkManager.service
 
 # log packages
 wget http://KICK_HOST/kickstarts/package_postback.sh
 bash package_postback.sh CentOS_7_PVHVM
-
-/usr/bin/systemctl disable NetworkManager-wait-online.service
-/usr/bin/systemctl disable NetworkManager.service
 
 # clean up
 passwd -d root

--- a/Red_Hat_Enterprise_Linux_7_PVHVM.cfg
+++ b/Red_Hat_Enterprise_Linux_7_PVHVM.cfg
@@ -315,8 +315,9 @@ grub2-mkconfig
 wget http://dfw.rhn.rackspace.com/pub/rhn-org-trusted-ssl-cert-1.0-1.noarch.rpm
 rpm -Uvh rhn-org-trusted-ssl-cert*
 
-# fix dns
-echo "dns=none" >> /etc/NetworkManager/NetworkManager.conf
+# fix dns as NetworkManager conflicts with Nova-Agent
+/usr/bin/systemctl mask NetworkManager-wait-online.service
+/usr/bin/systemctl mask NetworkManager.service
 
 # log packages
 wget http://KICK_HOST/kickstarts/package_postback.sh


### PR DESCRIPTION
NetworkManager service was running alongside nova agent and causing dns to be empty