### PR TITLE
Ubuntu 1404 fixes

### DIFF
--- a/Ubuntu_14.04.cfg
+++ b/Ubuntu_14.04.cfg
@@ -55,6 +55,7 @@ preseed partman/mount_style select traditional
 preseed user-setup/allow-password-weak boolean true
 preseed cdrom-detect/eject boolean false
 preseed cloud-init/datasources string None, ConfigDrive
+preseed netcfg/target_network_config string loopback
 
 # apt preseeds, note the release versions here
 preseed apt-setup/security_host string mirror.rackspace.com
@@ -128,13 +129,6 @@ echo -n > /lib/udev/rules.d/75-persistent-net-generator.rules
 cat > /etc/cloud/cloud.cfg.d/90_dpkg.cfg <<'EOF'
 # to update this file, run dpkg-reconfigure cloud-init
 datasource_list: [ ConfigDrive, None ]
-EOF
-
-# minimal network conf that doesnt dhcp 
-# causes boot delay if left out, no bueno
-cat > /etc/network/interfaces <<'EOF'
-auto lo
-iface lo inet loopback
 EOF
 
 # stage a clean hosts file
@@ -261,10 +255,6 @@ rm -f /var/cache/apt/*cache.bin
 rm -f /var/lib/apt/lists/*_Packages
 # breaks newest nova-agent if removed
 #rm -f /etc/resolv.conf
-# this file copies the installer's /etc/network/interfaces to the VM 
-# but we want to overwrite that with a "clean" file instead
-# so we must disable that copying action in kickstart/preseed
-rm -f /usr/lib/finish-install.d/55netcfg-copy-config
 rm -f /root/.bash_history
 rm -f /root/.nano_history
 rm -f /root/.lesshst

--- a/Ubuntu_14.04.cfg
+++ b/Ubuntu_14.04.cfg
@@ -260,7 +260,10 @@ rm -f /root/.nano_history
 rm -f /root/.lesshst
 rm -f /root/.ssh/known_hosts
 rm -rf /tmp/tmp
-for k in $(find /var/log -type f); do echo > $k; done
-for k in $(find /tmp -type f); do rm -f $k; done
-for k in $(find /root -type f \( ! -iname ".*" \)); do rm -f $k; done
+find /var/log -type f -exec truncate -s 0 {} \;
+find /tmp -type f -delete
+find /root -type f ! -iname ".*" -delete
 
+%post --nochroot
+rm -f /usr/lib/finish-install.d/94save-logs
+%end

--- a/Ubuntu_14.04.cfg
+++ b/Ubuntu_14.04.cfg
@@ -11,7 +11,7 @@ keyboard us
 timezone --utc Etc/UTC
 
 #Root password
-rootpw --plaintext novaagentneedsunlockedrootaccountsowedeletepasswordinpost
+rootpw novaagentneedsunlockedrootaccountsowedeletepasswordinpost
 
 #Initial user
 user --disabled
@@ -245,7 +245,6 @@ wget http://KICK_HOST/kickstarts/package_postback.sh
 bash package_postback.sh Ubuntu_14.04
 
 # clean up
-passwd -d root
 apt-get -y clean
 apt-get -y autoremove
 sed -i '/.*cdrom.*/d' /etc/apt/sources.list
@@ -265,5 +264,7 @@ find /tmp -type f -delete
 find /root -type f ! -iname ".*" -delete
 
 %post --nochroot
+# root password will be handled by nova-agent
+rm -f /usr/lib/finish-install.d/06user-setup
 rm -f /usr/lib/finish-install.d/94save-logs
 %end

--- a/Ubuntu_14.04_KVM.cfg
+++ b/Ubuntu_14.04_KVM.cfg
@@ -197,6 +197,10 @@ rm -f /root/.nano_history
 rm -f /root/.lesshst
 rm -f /root/.ssh/known_hosts
 rm -rf /tmp/tmp
-for k in $(find /var/log -type f); do echo > $k; done
-for k in $(find /tmp -type f); do rm -f $k; done
-for k in $(find /root -type f \( ! -iname ".*" \)); do rm -f $k; done
+find /var/log -type f -exec truncate -s 0 {} \;
+find /tmp -type f -delete
+find /root -type f ! -iname ".*" -delete
+
+%post --nochroot
+rm -f /usr/lib/finish-install.d/94save-logs
+%end

--- a/Ubuntu_14.04_PVHVM.cfg
+++ b/Ubuntu_14.04_PVHVM.cfg
@@ -238,7 +238,10 @@ rm -f /root/.nano_history
 rm -f /root/.lesshst
 rm -f /root/.ssh/known_hosts
 rm -rf /tmp/tmp
-for k in $(find /var/log -type f); do echo > $k; done
-for k in $(find /tmp -type f); do rm -f $k; done
-for k in $(find /root -type f \( ! -iname ".*" \)); do rm -f $k; done
+find /var/log -type f -exec truncate -s 0 {} \;
+find /tmp -type f -delete
+find /root -type f ! -iname ".*" -delete
 
+%post --nochroot
+rm -f /usr/lib/finish-install.d/94save-logs
+%end

--- a/Ubuntu_14.04_PVHVM.cfg
+++ b/Ubuntu_14.04_PVHVM.cfg
@@ -56,6 +56,7 @@ preseed user-setup/allow-password-weak boolean true
 preseed cdrom-detect/eject boolean false
 #preseed cloud-init cloud-init/datasources multiselect None, ConfigDrive
 preseed cloud-init/datasources string None, ConfigDrive
+preseed netcfg/target_network_config string loopback
 
 # apt preseeds, note the release versions here
 preseed apt-setup/security_host string mirror.rackspace.com
@@ -129,13 +130,6 @@ echo -n > /lib/udev/rules.d/75-persistent-net-generator.rules
 cat > /etc/cloud/cloud.cfg.d/90_dpkg.cfg <<'EOF'
 # to update this file, run dpkg-reconfigure cloud-init
 datasource_list: [ ConfigDrive, None ]
-EOF
-
-# minimal network conf that doesnt dhcp 
-# causes boot delay if left out, no bueno
-cat > /etc/network/interfaces <<'EOF'
-auto lo
-iface lo inet loopback
 EOF
 
 # stage a clean hosts file
@@ -239,10 +233,6 @@ rm -f /var/cache/apt/*cache.bin
 rm -f /var/lib/apt/lists/*_Packages
 # breaks newest nova-agent if removed
 #rm -f /etc/resolv.conf
-# this file copies the installer's /etc/network/interfaces to the VM 
-# but we want to overwrite that with a "clean" file instead
-# so we must disable that copying action in kickstart/preseed
-rm -f /usr/lib/finish-install.d/55netcfg-copy-config
 rm -f /root/.bash_history
 rm -f /root/.nano_history
 rm -f /root/.lesshst

--- a/Ubuntu_14.04_PVHVM.cfg
+++ b/Ubuntu_14.04_PVHVM.cfg
@@ -11,7 +11,7 @@ keyboard us
 timezone --utc Etc/UTC
 
 #Root password
-rootpw --plaintext novaagentneedsunlockedrootaccountsowedeletepasswordinpost
+rootpw novaagentneedsunlockedrootaccountsowedeletepasswordinpost
 
 #Initial user
 user --disabled
@@ -223,7 +223,6 @@ wget http://KICK_HOST/kickstarts/package_postback.sh
 bash package_postback.sh Ubuntu_14.04_PVHVM
 
 # clean up
-passwd -d root
 apt-get -y clean
 apt-get -y autoremove
 sed -i '/.*cdrom.*/d' /etc/apt/sources.list
@@ -243,5 +242,7 @@ find /tmp -type f -delete
 find /root -type f ! -iname ".*" -delete
 
 %post --nochroot
+# root password will be handled by nova-agent
+rm -f /usr/lib/finish-install.d/06user-setup
 rm -f /usr/lib/finish-install.d/94save-logs
 %end

--- a/Ubuntu_14.04_PVHVM_Heat.cfg
+++ b/Ubuntu_14.04_PVHVM_Heat.cfg
@@ -11,7 +11,7 @@ keyboard us
 timezone --utc Etc/UTC
 
 #Root password
-rootpw --plaintext novaagentneedsunlockedrootaccountsowedeletepasswordinpost
+rootpw novaagentneedsunlockedrootaccountsowedeletepasswordinpost
 
 #Initial user
 user --disabled
@@ -228,7 +228,6 @@ wget http://KICK_HOST/kickstarts/package_postback.sh
 bash package_postback.sh Heat_Dev_Unmanaged_PVHVM
 
 # clean up
-passwd -d root
 apt-get -y clean
 apt-get -y autoremove
 sed -i '/.*cdrom.*/d' /etc/apt/sources.list
@@ -248,5 +247,7 @@ find /tmp -type f -delete
 find /root -type f ! -iname ".*" -delete
 
 %post --nochroot
+# root password will be handled by nova-agent
+rm -f /usr/lib/finish-install.d/06user-setup
 rm -f /usr/lib/finish-install.d/94save-logs
 %end

--- a/Ubuntu_14.04_PVHVM_Heat.cfg
+++ b/Ubuntu_14.04_PVHVM_Heat.cfg
@@ -56,6 +56,7 @@ preseed user-setup/allow-password-weak boolean true
 preseed cdrom-detect/eject boolean false
 #preseed cloud-init cloud-init/datasources multiselect None, ConfigDrive
 preseed cloud-init/datasources string None, ConfigDrive
+preseed netcfg/target_network_config string loopback
 
 # apt preseeds, note the release versions here
 preseed apt-setup/security_host string mirror.rackspace.com
@@ -129,13 +130,6 @@ echo -n > /lib/udev/rules.d/75-persistent-net-generator.rules
 cat > /etc/cloud/cloud.cfg.d/90_dpkg.cfg <<'EOF'
 # to update this file, run dpkg-reconfigure cloud-init
 datasource_list: [ ConfigDrive, None ]
-EOF
-
-# minimal network conf that doesnt dhcp 
-# causes boot delay if left out, no bueno
-cat > /etc/network/interfaces <<'EOF'
-auto lo
-iface lo inet loopback
 EOF
 
 # stage a clean hosts file
@@ -244,10 +238,6 @@ rm -f /var/cache/apt/*cache.bin
 rm -f /var/lib/apt/lists/*_Packages
 # breaks newest nova-agent if removed
 #rm -f /etc/resolv.conf
-# this file copies the installer's /etc/network/interfaces to the VM 
-# but we want to overwrite that with a "clean" file instead
-# so we must disable that copying action in kickstart/preseed
-rm -f /usr/lib/finish-install.d/55netcfg-copy-config
 rm -f /root/.bash_history
 rm -f /root/.nano_history
 rm -f /root/.lesshst

--- a/Ubuntu_14.04_PVHVM_Heat.cfg
+++ b/Ubuntu_14.04_PVHVM_Heat.cfg
@@ -253,7 +253,10 @@ rm -f /root/.nano_history
 rm -f /root/.lesshst
 rm -f /root/.ssh/known_hosts
 rm -rf /tmp/tmp
-for k in $(find /var/log -type f); do echo > $k; done
-for k in $(find /tmp -type f); do rm -f $k; done
-for k in $(find /root -type f \( ! -iname ".*" \)); do rm -f $k; done
+find /var/log -type f -exec truncate -s 0 {} \;
+find /tmp -type f -delete
+find /root -type f ! -iname ".*" -delete
 
+%post --nochroot
+rm -f /usr/lib/finish-install.d/94save-logs
+%end

--- a/Ubuntu_14.04_Teeth.cfg
+++ b/Ubuntu_14.04_Teeth.cfg
@@ -103,3 +103,7 @@ cd /tmp/tmp
 wget http://KICK_HOST/kickstarts/Ubuntu_14.04_Teeth_post.sh
 chmod +x Ubuntu_14.04_Teeth_post.sh
 bash Ubuntu_14.04_Teeth_post.sh
+
+%post --nochroot
+rm -f /usr/lib/finish-install.d/94save-logs
+%end

--- a/Ubuntu_14.04_Teeth_post.sh
+++ b/Ubuntu_14.04_Teeth_post.sh
@@ -190,10 +190,6 @@ passwd -l root
 apt-get -y clean
 #apt-get -y autoremove
 sed -i '/.*cdrom.*/d' /etc/apt/sources.list
-# this file copies the installer's /etc/network/interfaces to the VM
-# but we want to overwrite that with a "clean" file instead
-# so we must disable that copying action in kickstart/preseed
-rm -f /usr/lib/finish-install.d/55netcfg-copy-config
 rm -f /etc/ssh/ssh_host_*
 rm -f /var/cache/apt/archives/*.deb
 rm -f /var/cache/apt/*cache.bin

--- a/Ubuntu_14.04_Teeth_post.sh
+++ b/Ubuntu_14.04_Teeth_post.sh
@@ -203,6 +203,6 @@ rm -f /root/.nano_history
 rm -f /root/.lesshst
 rm -f /root/.ssh/known_hosts
 rm -rf /tmp/tmp
-for k in $(find /var/log -type f); do echo > $k; done
-for k in $(find /tmp -type f); do rm -f $k; done
-for k in $(find /root -type f \( ! -iname ".*" \)); do rm -f $k; done
+find /var/log -type f -exec truncate -s 0 {} \;
+find /tmp -type f -delete
+find /root -type f ! -iname ".*" -delete


### PR DESCRIPTION
This set of changes will correct the way we're handling the network interfaces file by using a preseed value instead of hacks which are no longer working.  This also corrects log truncation for the images, as well as setting/removing root's password.