### PR TITLE
RHEL/CentOS 5 IPv6 firewall fixes

### DIFF
--- a/CentOS_5.cfg
+++ b/CentOS_5.cfg
@@ -126,7 +126,7 @@ cat > /etc/sysconfig/ip6tables <<'EOF'
 :FORWARD ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
 -A INPUT -i lo -j ACCEPT
--A INPUT -p icmpv6 -j ACCEPT
+-A INPUT -p ipv6-icmp -j ACCEPT
 -A INPUT -p udp -m udp --dport 32768:61000 -j ACCEPT
 -A INPUT -p tcp -m tcp --dport 32768:61000 ! --syn -j ACCEPT
 -A INPUT -m tcp -p tcp --dport 22 -j ACCEPT

--- a/CentOS_5.cfg
+++ b/CentOS_5.cfg
@@ -125,12 +125,12 @@ cat > /etc/sysconfig/ip6tables <<'EOF'
 :INPUT ACCEPT [0:0]
 :FORWARD ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
--A INPUT -p ipv6-icmp -j ACCEPT
 -A INPUT -i lo -j ACCEPT
--A INPUT -m conntrack --ctstate NEW -m tcp -p tcp --dport 22 -j ACCEPT
+-A INPUT -p icmpv6 -j ACCEPT
+-A INPUT -p udp -m udp --dport 32768:61000 -j ACCEPT
+-A INPUT -p tcp -m tcp --dport 32768:61000 ! --syn -j ACCEPT
+-A INPUT -m tcp -p tcp --dport 22 -j ACCEPT
 -A INPUT -j REJECT --reject-with icmp6-adm-prohibited
--A FORWARD -j REJECT --reject-with icmp6-adm-prohibited
 COMMIT
 EOF
 

--- a/CentOS_5.cfg
+++ b/CentOS_5.cfg
@@ -131,6 +131,7 @@ cat > /etc/sysconfig/ip6tables <<'EOF'
 -A INPUT -p tcp -m tcp --dport 32768:61000 ! --syn -j ACCEPT
 -A INPUT -m tcp -p tcp --dport 22 -j ACCEPT
 -A INPUT -j REJECT --reject-with icmp6-adm-prohibited
+-A FORWARD -j REJECT --reject-with icmp6-adm-prohibited
 COMMIT
 EOF
 

--- a/Red_Hat_Enterprise_Linux_5.cfg
+++ b/Red_Hat_Enterprise_Linux_5.cfg
@@ -118,7 +118,7 @@ cat > /etc/sysconfig/ip6tables <<'EOF'
 :FORWARD ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
 -A INPUT -i lo -j ACCEPT
--A INPUT -p icmpv6 -j ACCEPT
+-A INPUT -p ipv6-icmp -j ACCEPT
 -A INPUT -p udp -m udp --dport 32768:61000 -j ACCEPT
 -A INPUT -p tcp -m tcp --dport 32768:61000 ! --syn -j ACCEPT
 -A INPUT -m tcp -p tcp --dport 22 -j ACCEPT

--- a/Red_Hat_Enterprise_Linux_5.cfg
+++ b/Red_Hat_Enterprise_Linux_5.cfg
@@ -123,6 +123,7 @@ cat > /etc/sysconfig/ip6tables <<'EOF'
 -A INPUT -p tcp -m tcp --dport 32768:61000 ! --syn -j ACCEPT
 -A INPUT -m tcp -p tcp --dport 22 -j ACCEPT
 -A INPUT -j REJECT --reject-with icmp6-adm-prohibited
+-A FORWARD -j REJECT --reject-with icmp6-adm-prohibited
 COMMIT
 EOF
 

--- a/Red_Hat_Enterprise_Linux_5.cfg
+++ b/Red_Hat_Enterprise_Linux_5.cfg
@@ -117,12 +117,12 @@ cat > /etc/sysconfig/ip6tables <<'EOF'
 :INPUT ACCEPT [0:0]
 :FORWARD ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
--A INPUT -p ipv6-icmp -j ACCEPT
 -A INPUT -i lo -j ACCEPT
--A INPUT -m conntrack --ctstate NEW -m tcp -p tcp --dport 22 -j ACCEPT
+-A INPUT -p icmpv6 -j ACCEPT
+-A INPUT -p udp -m udp --dport 32768:61000 -j ACCEPT
+-A INPUT -p tcp -m tcp --dport 32768:61000 ! --syn -j ACCEPT
+-A INPUT -m tcp -p tcp --dport 22 -j ACCEPT
 -A INPUT -j REJECT --reject-with icmp6-adm-prohibited
--A FORWARD -j REJECT --reject-with icmp6-adm-prohibited
 COMMIT
 EOF
 


### PR DESCRIPTION
Connection tracking was broken in RHEL/CentOS 5 kernels, so the rules we provided weren't being applied correctly.  This implements primitive connection tracking with rules provided by 'lokkit'