### PR TITLE
Streamline the CentOS/RHEL 5 kicks and use the repackaged nova-agent

### DIFF
--- a/CentOS_5.cfg
+++ b/CentOS_5.cfg
@@ -60,38 +60,24 @@ epel-release
 %post --erroronfail
 
 # tmp tmp
-mkdir /tmp/tmp
-cd /tmp/tmp
+mkdir /tmp/tools-install
+cd /tmp/tools-install
 
 # install xen tools
-#wget http://ce3598b91333d7474379-b85ce4d8c2253d3876bef92f62a263f8.r84.cf5.rackcdn.com/xe-guest-utilities-6.2.0-1120.x86_64.rpm
-#wget http://ce3598b91333d7474379-b85ce4d8c2253d3876bef92f62a263f8.r84.cf5.rackcdn.com/xe-guest-utilities-xenstore-6.2.0-1120.x86_64.rpm
-#wget http://ce3598b91333d7474379-b85ce4d8c2253d3876bef92f62a263f8.r84.cf5.rackcdn.com/xe-guest-utilities-6.2.0-1120.x86_64.rpm
-#wget http://ce3598b91333d7474379-b85ce4d8c2253d3876bef92f62a263f8.r84.cf5.rackcdn.com/xe-guest-utilities-xenstore-6.2.0-1120.x86_64.rpm
-wget http://ce3598b91333d7474379-b85ce4d8c2253d3876bef92f62a263f8.r84.cf5.rackcdn.com/xe-guest-utilities-6.1.0-1037.x86_64.rpm
-wget http://ce3598b91333d7474379-b85ce4d8c2253d3876bef92f62a263f8.r84.cf5.rackcdn.com/xe-guest-utilities-xenstore-6.1.0-1037.x86_64.rpm
-rpm -Uhv xe-guest-utilities*.rpm
+wget http://ce3598b91333d7474379-b85ce4d8c2253d3876bef92f62a263f8.r84.cf5.rackcdn.com/xe-guest-utilities-6.1.0-1037.x86_64.rpm -O /tmp/tools-install/xe-guest-utilities.rpm
+wget http://ce3598b91333d7474379-b85ce4d8c2253d3876bef92f62a263f8.r84.cf5.rackcdn.com/xe-guest-utilities-xenstore-6.1.0-1037.x86_64.rpm -O /tmp/tools-install/xe-guest-utilities-xenstore.rpm
+rpm -Uhv /tmp/tools-install/xe-guest-utilities*.rpm
 
 # install agent
-wget -O nova-agent-1.39-1.x86_64.rpm --timeout=60 https://github.com/rackerlabs/openstack-guest-agents-unix/releases/download/1.39.1/nova-agent-1.39-1.x86_64.rpm
-rpm -Uhv --nosignature nova-agent*.rpm
+wget https://github.com/carlwgeorge/nova-agent-rpm/releases/download/1.39.1-2/nova-agent-1.39.1-2.el5.x86_64.rpm -O /tmp/tools-install/nova-agent.rpm
+rpm -U /tmp/tools-install/nova-agent.rpm
 
-# this fails it seems, but not required anyway
 #cat >> /etc/modprobe.d/blacklist <<EOF
 # disable non virtualized network modules that would load anyway
 #8139cp
 #8139too
 #e1000
 #EOF
-
-# setup systemd to boot to the right runlevel
-echo -n "Setting default runlevel to multiuser text mode"
-rm -f /etc/systemd/system/default.target
-ln -s /lib/systemd/system/multi-user.target /etc/systemd/system/default.target
-
-# If you want to remove rsyslog and just use journald, remove this!
-echo -n "Disabling persistent journal"
-rmdir /var/log/journal/ 
 
 # this is installed by default but we don't need it in virt
 echo "Removing linux-firmware package."
@@ -135,13 +121,6 @@ cat > /etc/sysconfig/ip6tables <<'EOF'
 COMMIT
 EOF
 
-echo -n "Getty fixes"
-# although we want console output going to the serial console, we don't
-# actually have the opportunity to login there. FIX.
-# we don't really need to auto-spawn _any_ gettys.
-sed -i '/^#NAutoVTs=.*/ a\
-NAutoVTs=0' /etc/systemd/logind.conf
-
 echo -n "Network fixes"
 # initscripts don't like this file to be missing.
 cat > /etc/sysconfig/network << EOF
@@ -168,12 +147,6 @@ cat > /etc/hosts << EOF
 127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
 ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
 EOF
-
-# Because memory is scarce resource in most cloud/virt environments,
-# and because this impedes forensics, we are differing from the Fedora
-# default of having /tmp on tmpfs.
-echo "Disabling tmpfs for /tmp."
-systemctl mask tmp.mount
 
 # set some stuff
 echo 'net.ipv4.conf.eth0.arp_notify = 1' >> /etc/sysctl.conf
@@ -223,14 +196,14 @@ mkinitrd -v --with=xenblk --with=xennet --preload=xenblk --preload=xennet --omit
 wget http://KICK_HOST/kickstarts/package_postback.sh
 bash package_postback.sh CentOS_5
 
-# workaround for rpm database showing rpm verify errors
-rm -f /var/lib/__db*
-rpm --rebuilddb
+# workaround for rpm database showing rpm verify errors (SH: not needed with new nova-agent)
+#rm -f /var/lib/__db*
+#rpm --rebuilddb
 
 # clean up
+cd /
 passwd -d root
 yum clean all
-truncate -c -s 0 /var/log/yum.log
 rm -f /root/anaconda-ks.cfg
 rm -f /etc/ssh/ssh_host_*
 rm -f /etc/resolv.conf
@@ -238,7 +211,7 @@ rm -f /root/.bash_history
 rm -f /root/.nano_history
 rm -f /root/.lesshst
 rm -f /root/.ssh/known_hosts
-rm -rf /tmp/tmp
-for k in $(find /var/log -type f); do truncate -s 0 $k; done
-for k in $(find /tmp -type f); do rm -f $k; done
-for k in $(find /root -type f \( ! -iname ".*" \)); do rm -f $k; done
+rm -rf /tmp/tools-install
+find /var/log -type f -exec cp -f /dev/null {} \;
+find /tmp -type f -delete
+find /root -type f ! -iname ".*" -delete

--- a/Red_Hat_Enterprise_Linux_5.cfg
+++ b/Red_Hat_Enterprise_Linux_5.cfg
@@ -76,15 +76,6 @@ cat >> /etc/modprobe.d/blacklist <<EOF
 e1000
 EOF
 
-# setup systemd to boot to the right runlevel
-echo -n "Setting default runlevel to multiuser text mode"
-rm -f /etc/systemd/system/default.target
-ln -s /lib/systemd/system/multi-user.target /etc/systemd/system/default.target
-
-# If you want to remove rsyslog and just use journald, remove this!
-echo -n "Disabling persistent journal"
-rmdir /var/log/journal/ 
-
 # this is installed by default but we don't need it in virt
 echo "Removing linux-firmware package."
 yum -C -y remove linux-firmware
@@ -127,13 +118,6 @@ cat > /etc/sysconfig/ip6tables <<'EOF'
 COMMIT
 EOF
 
-#echo -n "Getty fixes"
-# although we want console output going to the serial console, we don't
-# actually have the opportunity to login there. FIX.
-# we don't really need to auto-spawn _any_ gettys.
-sed -i '/^#NAutoVTs=.*/ a\
-NAutoVTs=0' /etc/systemd/logind.conf
-
 #echo -n "Network fixes"
 # initscripts don't like this file to be missing.
 cat > /etc/sysconfig/network << EOF
@@ -161,28 +145,18 @@ cat > /etc/hosts << EOF
 ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
 EOF
 
-# Because memory is scarce resource in most cloud/virt environments,
-# and because this impedes forensics, we are differing from the Fedora
-# default of having /tmp on tmpfs.
-echo "Disabling tmpfs for /tmp."
-systemctl mask tmp.mount
-
-# tmp tmp
-mkdir /tmp/tmp
-cd /tmp/tmp
+# tmp guest tools
+mkdir /tmp/tools-install
+cd /tmp/tools-install
 
 # install xen tools
-#wget http://ce3598b91333d7474379-b85ce4d8c2253d3876bef92f62a263f8.r84.cf5.rackcdn.com/xe-guest-utilities-6.2.0-1120.x86_64.rpm
-#wget http://ce3598b91333d7474379-b85ce4d8c2253d3876bef92f62a263f8.r84.cf5.rackcdn.com/xe-guest-utilities-xenstore-6.2.0-1120.x86_64.rpm
-#wget http://ce3598b91333d7474379-b85ce4d8c2253d3876bef92f62a263f8.r84.cf5.rackcdn.com/xe-guest-utilities-6.2.0-1120.x86_64.rpm
-#wget http://ce3598b91333d7474379-b85ce4d8c2253d3876bef92f62a263f8.r84.cf5.rackcdn.com/xe-guest-utilities-xenstore-6.2.0-1120.x86_64.rpm
-wget http://ce3598b91333d7474379-b85ce4d8c2253d3876bef92f62a263f8.r84.cf5.rackcdn.com/xe-guest-utilities-6.1.0-1037.x86_64.rpm
-wget http://ce3598b91333d7474379-b85ce4d8c2253d3876bef92f62a263f8.r84.cf5.rackcdn.com/xe-guest-utilities-xenstore-6.1.0-1037.x86_64.rpm
-rpm -Uhv xe-guest-utilities*.rpm
+wget http://ce3598b91333d7474379-b85ce4d8c2253d3876bef92f62a263f8.r84.cf5.rackcdn.com/xe-guest-utilities-6.1.0-1037.x86_64.rpm -O /tmp/tools-install/xe-guest-utilities.rpm
+wget http://ce3598b91333d7474379-b85ce4d8c2253d3876bef92f62a263f8.r84.cf5.rackcdn.com/xe-guest-utilities-xenstore-6.1.0-1037.x86_64.rpm -O /tmp/tools-install/xe-guest-utilities-xenstore.rpm
+rpm -Uhv /tmp/tools-install/xe-guest-utilities*.rpm
 
-# install agent
-wget -O nova-agent-1.39-1.x86_64.rpm https://github.com/rackerlabs/openstack-guest-agents-unix/releases/download/1.39.1/nova-agent-1.39-1.x86_64.rpm
-rpm -Uhv --nosignature nova-agent*.rpm
+# install nova-agent
+wget https://github.com/carlwgeorge/nova-agent-rpm/releases/download/1.39.1-2/nova-agent-1.39.1-2.el5.x86_64.rpm -O /tmp/tools-install/nova-agent.rpm
+rpm -U /tmp/tools-install/nova-agent.rpm
 
 # set some stuff
 echo 'net.ipv4.conf.eth0.arp_notify = 1' >> /etc/sysctl.conf
@@ -206,14 +180,6 @@ sed -i 's%#baseurl.*%baseurl=http://mirror.rackspace.com/epel/5/x86_64/%g' /etc/
 sed -i '/mirrorlist/s/^/#/' /etc/yum.repos.d/epel.repo
 sed -i '/baseurl/s/# *//' /etc/yum.repos.d/epel.repo
 
-cat >> /etc/yum.repos.d/rhel-source.repo <<'EOF'
-[rhel-source]
-name=Red Hat Enterprise Linux $releasever - $basearch - Source
-baseurl=http://intra.mirror.rackspace.com/kickstart/rhel-x86_64-server-5/
-enabled=1
-gpgcheck=0
-EOF
-
 # update all
 yum -y update
 
@@ -233,8 +199,7 @@ rm /boot/initrd-$version.img
 mkinitrd -v --with=xenblk --with=xennet --preload=xenblk --preload=xennet --omit-scsi-modules --omit-raid-modules /boot/initrd-$version.img $version
 
 # make sure repos are empty for rhel
-for k in $(find /etc/yum.repos.d -type f\( ! -name "*epel*" \)); do rm -f $k; done
-echo > /etc/yum.repos.d/rhel-source.repo
+find /etc/yum.repos.d -type f ! -name "*epel*" -delete
 
 # force grub to use generic disk labels, bootloader above does not do this
 sed -i 's%root=.*%root=/dev/xvda1%g' /boot/grub/grub.conf
@@ -250,9 +215,9 @@ wget http://KICK_HOST/kickstarts/package_postback.sh
 bash package_postback.sh Red_Hat_Enterprise_Linux_5
 
 # clean up
+cd /
 passwd -d root
 yum clean all
-truncate -c -s 0 /var/log/yum.log
 rm -f /root/anaconda-ks.cfg
 rm -f /etc/ssh/ssh_host_*
 rm -f /etc/resolv.conf
@@ -260,7 +225,7 @@ rm -f /root/.bash_history
 rm -f /root/.nano_history
 rm -f /root/.lesshst
 rm -f /root/.ssh/known_hosts
-rm -rf /tmp/tmp
-for k in $(find /var/log -type f); do echo > $k; done
-for k in $(find /tmp -type f); do rm -f $k; done
-for k in $(find /root -type f \( ! -iname ".*" \)); do rm -f $k; done
+rm -rf /tmp/tools-install
+find /var/log -type f -exec cp -f /dev/null {} \;
+find /tmp -type f -delete
+find /root -type f ! -iname ".*" -delete


### PR DESCRIPTION
Removed unneeded systemd stuff, cleaned up a few things, and switched over to using the repackaged nova-agent, which will resolve the RPM db errors in RHEL 5