### PR TITLE
Upgrading setuptools version to fix issue with Ansible

### DIFF
--- a/Ubuntu_14.04_PVHVM_Heat_post.sh
+++ b/Ubuntu_14.04_PVHVM_Heat_post.sh
@@ -767,6 +767,12 @@ chmod 0700 /usr/bin/heat-config-notify
 # https://github.com/rackerlabs/base-image-blueprints/pull/40
 pip install wrapt monotonic pytz funcsigs positional
 
+# The following package is installed, but out of date and is
+# causing Ansible to fail to run properly.
+# For more background, see:
+# https://github.com/rackerlabs/base-image-blueprints/pull/41
+pip install --upgrade setuptools
+
 # Install SoftwareConfig and Ansible via PIP
 pip install ansible os-collect-config os-apply-config os-refresh-config dib-utils
 


### PR DESCRIPTION
Ubuntu/PIP comes with SetupTools 3.3.  The latest version of SetupTools is 21.2, and the version required for Ansible is anything higher than 11.3.