### PR TITLE
Add sosreport package to RHEL kicks

### DIFF
--- a/Red_Hat_Enterprise_Linux_5.cfg
+++ b/Red_Hat_Enterprise_Linux_5.cfg
@@ -66,6 +66,9 @@ rhn-setup
 rhn-check
 sudo
 epel-release
+sos
+xz
+xz-libs
 
 %post --erroronfail
 

--- a/Red_Hat_Enterprise_Linux_6.cfg
+++ b/Red_Hat_Enterprise_Linux_6.cfg
@@ -54,6 +54,9 @@ curl
 openssh-clients
 epel-release
 cloud-init
+sos
+xz
+xz-libs
 
 %end
 

--- a/Red_Hat_Enterprise_Linux_6_PVHVM.cfg
+++ b/Red_Hat_Enterprise_Linux_6_PVHVM.cfg
@@ -58,6 +58,9 @@ cloud-utils
 cloud-utils-growpart
 dracut-modules-growroot
 parted
+sos
+xz
+xz-libs
 
 %end
 

--- a/Red_Hat_Enterprise_Linux_7_PVHVM.cfg
+++ b/Red_Hat_Enterprise_Linux_7_PVHVM.cfg
@@ -73,6 +73,9 @@ iptables-services
 cloud-init
 cloud-utils
 cloud-utils-growpart
+sos
+xz
+xz-libs
 # all below are required for cloud-init
 epel-release
 python-devel

--- a/Red_Hat_Enterprise_Linux_7_Teeth.cfg
+++ b/Red_Hat_Enterprise_Linux_7_Teeth.cfg
@@ -78,6 +78,9 @@ rsyslog
 python-pip
 -selinux-policy-targeted
 mdadm
+sos
+xz
+xz-libs
 
 %end
 


### PR DESCRIPTION
Per request related to issues around RHEL 6.8 release, we're adding the sosreport package to RHEL images so that we can more quickly gather diagnostics for Red Hat Support.