### PR TITLE
Revert "Merge pull request #37 from rackerlabs/add-OM-pw-support"

### DIFF
--- a/CentOS_6_Teeth_post.sh
+++ b/CentOS_6_Teeth_post.sh
@@ -167,7 +167,7 @@ system_info:
   ssh_svcname: sshd
   default_user:
     name: root
-    lock_passwd: False
+    lock_passwd: True
     gecos: CentOS cloud-init user
     shell: /bin/bash
 cloud_config_modules:
@@ -200,6 +200,7 @@ bash package_postback.sh CentOS_6_Teeth
 # clean up
 yum clean all
 passwd -d root
+passwd -l root
 truncate -c -s 0 /var/log/yum.log
 rm -f /etc/ssh/ssh_host_*
 rm -f /etc/resolv.conf

--- a/CentOS_7_Teeth.cfg
+++ b/CentOS_7_Teeth.cfg
@@ -197,7 +197,7 @@ pip install --upgrade configobj
 
 cat > /etc/cloud/cloud.cfg.d/10_rackspace.cfg <<'EOF'
 disable_root: False
-ssh_pwauth: True
+ssh_pwauth: False
 ssh_deletekeys: False
 resize_rootfs: noblock
 manage_etc_hosts: localhost
@@ -208,7 +208,7 @@ system_info:
   distro: rhel
   default_user:
     name: root
-    lock_passwd: False
+    lock_passwd: True
 ssh_svcname: ssh
 mounts:
  - [ ephemeral0, null ]
@@ -300,6 +300,7 @@ bash package_postback.sh CentOS_7_Teeth
 
 # clean up
 passwd -d root
+passwd -l root
 yum clean all
 truncate -c -s 0 /var/log/yum.log
 echo "" > /etc/machine-id

--- a/Debian_8_Teeth_post.sh
+++ b/Debian_8_Teeth_post.sh
@@ -53,7 +53,7 @@ EOF
 # our cloud-init config
 cat > /etc/cloud/cloud.cfg.d/10_rackspace.cfg <<'EOF'
 disable_root: False
-ssh_pwauth: True
+ssh_pwauth: False
 ssh_deletekeys: False
 resize_rootfs: noblock
 manage_etc_hosts: localhost
@@ -62,7 +62,7 @@ system_info:
    distro: debian
    default_user:
      name: root
-     lock_passwd: False
+     lock_passwd: True
      gecos: Debian
      shell: /bin/bash
 mounts:
@@ -176,6 +176,7 @@ bash package_postback.sh Debian_8_Teeth
 
 # clean up
 passwd -d root
+passwd -l root
 apt-get -y clean
 apt-get -y autoremove
 rm -f /etc/ssh/ssh_host_*

--- a/Debian_Testing_Teeth_post.sh
+++ b/Debian_Testing_Teeth_post.sh
@@ -52,7 +52,7 @@ EOF
 # our cloud-init config
 cat > /etc/cloud/cloud.cfg.d/10_rackspace.cfg <<'EOF'
 disable_root: False
-ssh_pwauth: True
+ssh_pwauth: False
 ssh_deletekeys: False
 resize_rootfs: noblock
 manage_etc_hosts: localhost
@@ -61,7 +61,7 @@ system_info:
    distro: debian
    default_user:
      name: root
-     lock_passwd: False
+     lock_passwd: True
      gecos: Debian
      shell: /bin/bash
 
@@ -200,6 +200,7 @@ bash package_postback.sh Debian_Testing_Teeth
 
 # clean up
 passwd -d root
+passwd -l root
 apt-get -y clean
 apt-get -y autoremove
 rm -f /etc/ssh/ssh_host_*

--- a/Debian_Unstable_Teeth_post.sh
+++ b/Debian_Unstable_Teeth_post.sh
@@ -52,7 +52,7 @@ EOF
 # our cloud-init config
 cat > /etc/cloud/cloud.cfg.d/10_rackspace.cfg <<'EOF'
 disable_root: False
-ssh_pwauth: True
+ssh_pwauth: False
 ssh_deletekeys: False
 resize_rootfs: noblock
 manage_etc_hosts: localhost
@@ -61,7 +61,7 @@ system_info:
    distro: debian
    default_user:
      name: root
-     lock_passwd: False
+     lock_passwd: True
      gecos: Debian
      shell: /bin/bash
 
@@ -211,6 +211,7 @@ bash package_postback.sh Debian_Unstable_Teeth
 
 # clean up
 passwd -d root
+passwd -l root
 apt-get -y clean
 apt-get -y autoremove
 rm -f /etc/ssh/ssh_host_*

--- a/Fedora_22_Teeth.cfg
+++ b/Fedora_22_Teeth.cfg
@@ -211,7 +211,7 @@ sed -i 's%cmd.append("-t")%#cmd.append("-t")%' /usr/lib/python2.7/site-packages/
 cat > /etc/cloud/cloud.cfg.d/10_rackspace.cfg <<'EOF'
 datasource_list: [ ConfigDrive, None ]
 disable_root: False
-ssh_pwauth: True
+ssh_pwauth: False
 ssh_deletekeys: False
 resize_rootfs: noblock
 manage_etc_hosts: localhost
@@ -222,7 +222,7 @@ system_info:
   distro: fedora
   default_user:
     name: root
-    lock_passwd: False
+    lock_passwd: True
 
 cloud_config_modules:
  - disk_setup
@@ -355,6 +355,7 @@ echo "done"
 # clean up
 rm -f /etc/sysconfig/network-scripts/ifcfg-ens3
 passwd -d root
+passwd -l root
 yum clean all
 truncate -c -s 0 /var/log/yum.log
 echo "" > /etc/machine-id

--- a/Fedora_23_Teeth.cfg
+++ b/Fedora_23_Teeth.cfg
@@ -206,7 +206,7 @@ sed -i 's%cmd.append("-t")%#cmd.append("-t")%' /usr/lib/python3.4/site-packages/
 cat > /etc/cloud/cloud.cfg.d/10_rackspace.cfg <<'EOF'
 datasource_list: [ ConfigDrive, None ]
 disable_root: False
-ssh_pwauth: True
+ssh_pwauth: False
 ssh_deletekeys: False
 resize_rootfs: noblock
 manage_etc_hosts: localhost
@@ -217,7 +217,7 @@ system_info:
   distro: fedora
   default_user:
     name: root
-    lock_passwd: False
+    lock_passwd: True
 
 cloud_config_modules:
  - disk_setup
@@ -350,6 +350,7 @@ echo "done"
 # clean up
 rm -f /etc/sysconfig/network-scripts/ifcfg-ens3
 passwd -d root
+passwd -l root
 yum clean all
 truncate -c -s 0 /var/log/yum.log
 echo "" > /etc/machine-id

--- a/Red_Hat_Enterprise_Linux_7_Teeth.cfg
+++ b/Red_Hat_Enterprise_Linux_7_Teeth.cfg
@@ -216,7 +216,7 @@ EOF
 
 cat > /etc/cloud/cloud.cfg.d/10_rackspace.cfg <<'EOF'
 disable_root: False
-ssh_pwauth: True
+ssh_pwauth: False
 ssh_deletekeys: False
 resize_rootfs: noblock
 manage_etc_hosts: localhost
@@ -227,7 +227,7 @@ system_info:
   distro: rhel
   default_user:
     name: root
-    lock_passwd: False
+    lock_passwd: True
 ssh_svcname: ssh
 mounts:
  - [ ephemeral0, null ]
@@ -319,6 +319,7 @@ bash package_postback.sh Red_Hat_Enterprise_Linux_7_Teeth
 
 # clean up
 passwd -d root
+passwd -l root
 yum clean all
 truncate -c -s 0 /var/log/yum.log
 echo "" > /etc/machine-id

--- a/Ubuntu_14.04_Teeth_post.sh
+++ b/Ubuntu_14.04_Teeth_post.sh
@@ -31,7 +31,7 @@ sed -i 's/WARNING/DEBUG/g' /etc/cloud/cloud.cfg.d/05_logging.cfg
 # our cloud-init config
 cat > /etc/cloud/cloud.cfg.d/10_rackspace.cfg <<'EOF'
 disable_root: False
-ssh_pwauth: True
+ssh_pwauth: False
 ssh_deletekeys: False
 resize_rootfs: noblock
 manage_etc_hosts: localhost
@@ -40,7 +40,7 @@ system_info:
    distro: ubuntu
    default_user:
      name: root
-     lock_passwd: False
+     lock_passwd: True
      gecos: Ubuntu
      shell: /bin/bash
 
@@ -152,6 +152,7 @@ bash package_postback.sh Ubuntu_14.04_Teeth
 
 # clean up
 passwd -d root
+passwd -l root
 apt-get -y clean
 sed -i '/.*cdrom.*/d' /etc/apt/sources.list
 rm -f /etc/ssh/ssh_host_*

--- a/Ubuntu_15.10_Teeth_post.sh
+++ b/Ubuntu_15.10_Teeth_post.sh
@@ -28,7 +28,7 @@ sed -i 's/WARNING/DEBUG/g' /etc/cloud/cloud.cfg.d/05_logging.cfg
 # our cloud-init config
 cat > /etc/cloud/cloud.cfg.d/10_rackspace.cfg <<'EOF'
 disable_root: False
-ssh_pwauth: True
+ssh_pwauth: False
 ssh_deletekeys: False
 resize_rootfs: noblock
 manage_etc_hosts: localhost
@@ -37,7 +37,7 @@ system_info:
    distro: ubuntu
    default_user:
      name: root
-     lock_passwd: False
+     lock_passwd: True
      gecos: Ubuntu
      shell: /bin/bash
 bootcmd:
@@ -158,6 +158,7 @@ bash package_postback.sh Ubuntu_15.10_Teeth
 
 # clean up
 passwd -d root
+passwd -l root
 apt-get -y clean
 apt-get -y autoremove
 sed -i '/.*cdrom.*/d' /etc/apt/sources.list


### PR DESCRIPTION
We decided to drop our effort of adding password support to OM images awhile back. This is just updating the public repo to what is already reflected on our build servers.

This reverts commit b55f3a6a68de9902de9afc3a6ccd7dcffbf4a87c, reversing
changes made to 2c10730971fe9a83ca8680dc523f15fb1d3cdee4.