### PR TITLE
Change leftover PVHVM ext3 fs to ext4

### DIFF
--- a/CentOS_6_PVHVM.cfg
+++ b/CentOS_6_PVHVM.cfg
@@ -38,7 +38,7 @@ skipx
 # Setup the disk
 zerombr
 clearpart --all --initlabel
-part / --fstype=ext3 --grow --size=1024 --asprimary
+part / --fstype=ext4 --grow --size=1024 --asprimary
 # grub is replaced in %post now anyway
 bootloader --location=mbr --driveorder=xvda  --timeout=1
 
@@ -175,7 +175,7 @@ cat > /etc/fstab <<'EOF'
 # Accessible filesystems, by reference, are maintained under '/dev/disk'
 # See man pages fstab(5), findfs(8), mount(8) and/or blkid(8) for more info
 #
-/dev/xvda1		/                       ext3    defaults,noatime,barrier=0 1 1
+/dev/xvda1		/                       ext4    defaults,noatime,barrier=0 1 1
 tmpfs                   /dev/shm                tmpfs   defaults        0 0
 devpts                  /dev/pts                devpts  gid=5,mode=620  0 0
 sysfs                   /sys                    sysfs   defaults        0 0

--- a/Debian_7_PVHVM.cfg
+++ b/Debian_7_PVHVM.cfg
@@ -47,9 +47,9 @@ d-i partman-auto/disk /dev/xvda
 d-i partman-basicfilesystems/no_swap boolean false
 #d-i partman-auto/choose_recipe select atomic
 d-i partman-auto/expert_recipe string \
-    root :: 100% 50 100% ext3 \
+    root :: 100% 50 100% ext4 \
         $primary{ } $bootable{ } method{ format } \
-        format{ } use_filesystem{ } filesystem{ ext3 } \
+        format{ } use_filesystem{ } filesystem{ ext4 } \
         mountpoint{ / } \
     . \
 

--- a/Debian_7_PVHVM_post.sh
+++ b/Debian_7_PVHVM_post.sh
@@ -70,7 +70,7 @@ cat > /etc/fstab <<'EOF'
 # that works even if disks are added and removed. See fstab(5).
 #
 # <file system> <mount point>   <type>  <options>       <dump>  <pass>
-/dev/xvda1  /               ext3    errors=remount-ro,noatime,barrier=0 0       1
+/dev/xvda1  /               ext4    errors=remount-ro,noatime,barrier=0 0       1
 #/dev/xvdc1 none            swap    sw              0       0
 EOF
 

--- a/Debian_8_PVHVM.cfg
+++ b/Debian_8_PVHVM.cfg
@@ -47,9 +47,9 @@ d-i partman-auto/disk /dev/xvda
 d-i partman-basicfilesystems/no_swap boolean false
 #d-i partman-auto/choose_recipe select atomic
 d-i partman-auto/expert_recipe string \
-	root :: 100% 50 100% ext3 \
+	root :: 100% 50 100% ext4 \
         $primary{ } $bootable{ } method{ format } \
-        format{ } use_filesystem{ } filesystem{ ext3 } \
+        format{ } use_filesystem{ } filesystem{ ext4 } \
         mountpoint{ / } \
 	. \
 d-i partman-partitioning/confirm_write_new_label boolean true

--- a/Debian_8_PVHVM_post.sh
+++ b/Debian_8_PVHVM_post.sh
@@ -63,7 +63,7 @@ cat > /etc/fstab <<'EOF'
 # that works even if disks are added and removed. See fstab(5).
 #
 # <file system> <mount point>   <type>  <options>       <dump>  <pass>
-/dev/xvda1	/               ext3    errors=remount-ro,noatime,barrier=0 0       1
+/dev/xvda1	/               ext4    errors=remount-ro,noatime,barrier=0 0       1
 #/dev/xvdc1	none            swap    sw              0       0
 EOF
 

--- a/Debian_Testing_PVHVM.cfg
+++ b/Debian_Testing_PVHVM.cfg
@@ -47,9 +47,9 @@ d-i partman-auto/disk /dev/xvda
 d-i partman-basicfilesystems/no_swap boolean false
 #d-i partman-auto/choose_recipe select atomic
 d-i partman-auto/expert_recipe string \
-	root :: 100% 50 100% ext3 \
+	root :: 100% 50 100% ext4 \
         $primary{ } $bootable{ } method{ format } \
-        format{ } use_filesystem{ } filesystem{ ext3 } \
+        format{ } use_filesystem{ } filesystem{ ext4 } \
         mountpoint{ / } \
 	. \
 d-i partman-partitioning/confirm_write_new_label boolean true

--- a/Debian_Testing_PVHVM_post.sh
+++ b/Debian_Testing_PVHVM_post.sh
@@ -63,7 +63,7 @@ cat > /etc/fstab <<'EOF'
 # that works even if disks are added and removed. See fstab(5).
 #
 # <file system> <mount point>   <type>  <options>       <dump>  <pass>
-/dev/xvda1	/               ext3    errors=remount-ro,noatime,barrier=0 0       1
+/dev/xvda1	/               ext4    errors=remount-ro,noatime,barrier=0 0       1
 #/dev/xvdc1	none            swap    sw              0       0
 EOF
 

--- a/Debian_Unstable_PVHVM.cfg
+++ b/Debian_Unstable_PVHVM.cfg
@@ -44,9 +44,9 @@ d-i partman-auto/disk /dev/xvda
 d-i partman-basicfilesystems/no_swap boolean false
 #d-i partman-auto/choose_recipe select atomic
 d-i partman-auto/expert_recipe string \
-	root :: 100% 50 100% ext3 \
+	root :: 100% 50 100% ext4 \
         $primary{ } $bootable{ } method{ format } \
-        format{ } use_filesystem{ } filesystem{ ext3 } \
+        format{ } use_filesystem{ } filesystem{ ext4 } \
         mountpoint{ / } \
 	. \
 d-i partman-partitioning/confirm_write_new_label boolean true

--- a/Debian_Unstable_PVHVM_post.sh
+++ b/Debian_Unstable_PVHVM_post.sh
@@ -63,7 +63,7 @@ cat > /etc/fstab <<'EOF'
 # that works even if disks are added and removed. See fstab(5).
 #
 # <file system> <mount point>   <type>  <options>       <dump>  <pass>
-/dev/xvda1	/               ext3    errors=remount-ro,noatime,barrier=0 0       1
+/dev/xvda1	/               ext4    errors=remount-ro,noatime,barrier=0 0       1
 #/dev/xvdc1	none            swap    sw              0       0
 EOF
 

--- a/Red_Hat_Enterprise_Linux_6_PVHVM.cfg
+++ b/Red_Hat_Enterprise_Linux_6_PVHVM.cfg
@@ -37,7 +37,7 @@ skipx
 # Setup the disk
 zerombr
 clearpart --all --initlabel
-part / --fstype=ext3 --grow --size=1024 --asprimary
+part / --fstype=ext4 --grow --size=1024 --asprimary
 bootloader --timeout=1 --append="console=hvc0"
 
 # Shutdown when the kickstart is done
@@ -172,7 +172,7 @@ cat > /etc/fstab <<'EOF'
 # Accessible filesystems, by reference, are maintained under '/dev/disk'
 # See man pages fstab(5), findfs(8), mount(8) and/or blkid(8) for more info
 #
-/dev/xvda1		/                       ext3    defaults,noatime,barrier=0 1 1
+/dev/xvda1		/                       ext4    defaults,noatime,barrier=0 1 1
 tmpfs                   /dev/shm                tmpfs   defaults        0 0
 devpts                  /dev/pts                devpts  gid=5,mode=620  0 0
 sysfs                   /sys                    sysfs   defaults        0 0

--- a/Scientific_Linux_6_PVHVM.cfg
+++ b/Scientific_Linux_6_PVHVM.cfg
@@ -168,7 +168,7 @@ cat > /etc/fstab <<'EOF'
 # Accessible filesystems, by reference, are maintained under '/dev/disk'
 # See man pages fstab(5), findfs(8), mount(8) and/or blkid(8) for more info
 #
-/dev/xvda1		/                       ext3    defaults,noatime,barrier=0 1 1
+/dev/xvda1		/                       ext4    defaults,noatime,barrier=0 1 1
 tmpfs                   /dev/shm                tmpfs   defaults        0 0
 devpts                  /dev/pts                devpts  gid=5,mode=620  0 0
 sysfs                   /sys                    sysfs   defaults        0 0


### PR DESCRIPTION
Some of these images had ext3 fs still in the kick due to PV compatability.
However all of these PVHVM images can safely be moved to ext4 now.