### PR TITLE
Restart network on CentOS6-Teeth for IPv6

### DIFF
--- a/CentOS_6_Teeth_post.sh
+++ b/CentOS_6_Teeth_post.sh
@@ -50,6 +50,7 @@ EOF
 
 # IPv6 does not come up on first boot unless you restart networking.
 echo -n "Writing initial network restart script"
+mkdir -p /var/lib/cloud/scripts/per-instance
 cat > /var/lib/cloud/scripts/per-instance/restartnetworkip6.sh <<'EOF'
 #!/bin/sh
 

--- a/CentOS_6_Teeth_post.sh
+++ b/CentOS_6_Teeth_post.sh
@@ -48,6 +48,21 @@ NETWORKING=yes
 NOZEROCONF=yes
 EOF
 
+# IPv6 does not come up on first boot unless you restart networking.
+echo -n "Writing initial network restart script"
+cat > /var/lib/cloud/scripts/per-instance/restartnetworkip6.sh <<'EOF'
+#!/bin/sh
+
+# IPv6 does not come up on first boot on CentOS 6 without a network restart.
+# This may be kernel related.
+# Revisit this if we unpin the kernel from 2.6.32-504.30.3.el6.x86_64
+
+service network restart
+
+EOF
+
+chmod a+x /var/lib/cloud/scripts/per-instance/restartnetworkip6.sh
+
 # For cloud images, 'eth0' _is_ the predictable device name, since
 # we don't want to be tied to specific virtual (!) hardware
 cat > /etc/udev/rules.d/70-persistent-net.rules <<'EOF'


### PR DESCRIPTION
On first boot, on CentOS6-Teeth IPv6 does not work until you do a
restart of the network service. Prior to this, the IPv6 address is set,
and routes are in place, but the network is unreachable, except, oddly,
the gateway.

After a network reset, everything works.
This is a work-around that just issues a network restart from the
cloud-init per-instance scripts. Ultimately, this may be kernel-related,
and we should check if this is still needed if we unpin the CentOS 6 kernel.

JIRA:IMG-240