### PR TITLE
Update CentOS_6.cfg to enable selinux

### DIFF
--- a/CentOS_6.cfg
+++ b/CentOS_6.cfg
@@ -24,7 +24,7 @@ rootpw --plaintext novaagentneedsunlockedrootaccountsowedeletepasswordinpost
 authconfig --enableshadow --passalgo=sha512
 
 # SELinux
-selinux --disabled
+selinux --permissive
 
 # Services running at boot
 services --enabled network,sshd
@@ -220,7 +220,7 @@ EOF
 sed -i '/touch $lockfile/a \ \ \ \ sleep 12' /etc/init.d/nova-agent
 
 # force grub to use generic disk labels, bootloader above does not do this
-sed -i 's%root=.*%root=/dev/xvda1 console=hvc0 selinux=0%g' /boot/grub/grub.conf
+sed -i 's%root=.*%root=/dev/xvda1 console=hvc0%g' /boot/grub/grub.conf
 sed -i 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/selinux/config
 
 # another inverse hackaround for our weird init stack


### PR DESCRIPTION
Update CentOS_6.cfg to enable selinux in permissive mode