### PR TITLE
IMG-370 Upgrade cloud-init to patched version

### DIFF
--- a/Fedora_25_PVHVM.cfg
+++ b/Fedora_25_PVHVM.cfg
@@ -155,7 +155,17 @@ sed -i 's%#baseurl=http://download.fedoraproject.org/pub/fedora/linux%baseurl=ht
 sed -i '/metalink/s/^/#/' /etc/yum.repos.d/*.repo
 
 # update all
-dnf -y update
+dnf --assumeyes update
+
+# if [ `rpm -q cloud-init` == 'cloud-init-0.7.9-4.fc25.noarch' ]; then echo 'Installed cloud-init version is 0.7.9-4.fc25'; fi;
+if [ `rpm -q cloud-init` == 'cloud-init-0.7.9-4.fc25.noarch' ]
+then
+    # Enable temporary patch repository for cloud-init-0.7.9-4.fc25
+    # Patch is a stop-gap for https://bugzilla.redhat.com/show_bug.cgi?id=1447708
+    wget https://copr-be.cloud.fedoraproject.org/results/carlgeorge/cloud-init-rhbz1447708/fedora-25-x86_64/00547940-cloud-init/cloud-init-0.7.9-5.1.fc25.noarch.rpm
+    rpm --upgrade cloud-init-0.7.9-5.1.fc25.noarch.rpm
+    rm cloud-init-0.7.9-5.1.fc25.noarch.rpm
+fi
 
 # if cloud-init starts before nova-agent configures the network many things fail, so we'll delay for a bit
 mkdir -p /etc/systemd/system/cloud-init.service.d


### PR DESCRIPTION
https://jira.rax.io/browse/IMG-370

The base image built from the Fedora 25 template failed the following cloud-init QC check on the instance:

```which zsh 2> /dev/null; if [ $? = 0 ]; then echo "cloud-init instance run was successful"; fi;```

Bug reference: https://bugzilla.redhat.com/show_bug.cgi?id=1447708