### PR TITLE
DFOT-2973: Fedora 30 pvhvm update

### DIFF
--- a/fedora_30_pvhvm.cfg
+++ b/fedora_30_pvhvm.cfg
@@ -1,10 +1,8 @@
-cmdline
-
-# Install from a friendly mirror and add updates
+url --url=http://mirror.rackspace.com/fedora/releases/30/Everything/x86_64/os/
 repo --name=fedora --baseurl=http://mirror.rackspace.com/fedora/releases/30/Everything/x86_64/os/
 repo --name=updates --baseurl=http://mirror.rackspace.com/fedora/updates/30/Everything/x86_64/
 repo --name=epel --baseurl=http://mirror.rackspace.com/epel/7/x86_64/
-url --url=http://mirror.rackspace.com/fedora/releases/30/Server/x86_64/os/
+
 
 
 # Language and keyboard setup
@@ -30,6 +28,7 @@ services --enabled chronyd,sshd,cloud-init-local,cloud-init,cloud-config,cloud-f
 
 # Disable anything graphical
 skipx
+text
 
 # Setup the disk
 clearpart --all
@@ -64,7 +63,6 @@ which
 PyYAML
 nmap-ncat
 nova-agent
-python2-dnf
 libnsl2-devel
 libtirpc-devel
 python2-crypto
@@ -157,7 +155,7 @@ systemctl enable xe-linux-distribution
 echo 'net.ipv4.conf.eth0.arp_notify = 1' >> /etc/sysctl.conf
 
 # After the patched kernel OOM kicks in on 512 instances. Setting swappiness so some swap space is used to prevent this
-echo 'vm.swappiness = 1' >> /etc/sysctl.conf
+echo 'vm.swappiness = 0' >> /etc/sysctl.conf
 
 cat >> /etc/sysctl.conf <<'EOF'
 net.ipv4.tcp_rmem = 4096 87380 33554432


### PR DESCRIPTION
url needs to be at the top of the kickstart file.  All other ways fail on Fedora 30.
Added 'text' so that it doesn't default to a GUI.
python2-dnf no longer in upstream repos, and I don't believe it is needed.