### PR TITLE
Switching to noop or none ioscheduler to save cycles

### DIFF
--- a/centos_7_pvhvm.cfg
+++ b/centos_7_pvhvm.cfg
@@ -156,6 +156,12 @@ echo -n > /etc/udev/rules.d/70-persistent-net.rules
 echo -n > /lib/udev/rules.d/75-persistent-net-generator.rules
 ln -s /dev/null /etc/udev/rules.d/80-net-name-slot.rules
 
+# Use noop scheduler to minimize CPU cycles
+cat > /etc/udev/rules.d/88-rax-ioscheduler.rules << EOF
+ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/scheduler}="noop"
+ACTION=="add|change", KERNEL=="xvd[a-z]", ATTR{queue/scheduler}="noop"
+EOF
+
 # simple eth0 config, again not hard-coded to the build hardware
 cat > /etc/sysconfig/network-scripts/ifcfg-eth0 << EOF
 DEVICE="eth0"

--- a/centos_7_pvhvm_heat.cfg
+++ b/centos_7_pvhvm_heat.cfg
@@ -154,6 +154,12 @@ echo -n > /etc/udev/rules.d/70-persistent-net.rules
 echo -n > /lib/udev/rules.d/75-persistent-net-generator.rules
 ln -s /dev/null /etc/udev/rules.d/80-net-name-slot.rules
 
+# Use noop scheduler to minimize CPU cycles
+cat > /etc/udev/rules.d/88-rax-ioscheduler.rules << EOF
+ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/scheduler}="noop"
+ACTION=="add|change", KERNEL=="xvd[a-z]", ATTR{queue/scheduler}="noop"
+EOF
+
 # simple eth0 config, again not hard-coded to the build hardware
 cat > /etc/sysconfig/network-scripts/ifcfg-eth0 << EOF
 DEVICE="eth0"

--- a/centos_8_pvhvm.cfg
+++ b/centos_8_pvhvm.cfg
@@ -152,10 +152,10 @@ echo -n > /etc/udev/rules.d/70-persistent-net.rules
 echo -n > /lib/udev/rules.d/75-persistent-net-generator.rules
 ln -s /dev/null /etc/udev/rules.d/80-net-name-slot.rules
 
-# Use noop scheduler to minimize CPU cycles
+# Use none scheduler to minimize CPU cycles
 cat > /etc/udev/rules.d/88-rax-ioscheduler.rules << EOF
-ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/scheduler}="noop"
-ACTION=="add|change", KERNEL=="xvd[a-z]", ATTR{queue/scheduler}="noop"
+ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/scheduler}="none"
+ACTION=="add|change", KERNEL=="xvd[a-z]", ATTR{queue/scheduler}="none"
 EOF
 
 # simple eth0 config, again not hard-coded to the build hardware

--- a/centos_8_pvhvm.cfg
+++ b/centos_8_pvhvm.cfg
@@ -152,6 +152,12 @@ echo -n > /etc/udev/rules.d/70-persistent-net.rules
 echo -n > /lib/udev/rules.d/75-persistent-net-generator.rules
 ln -s /dev/null /etc/udev/rules.d/80-net-name-slot.rules
 
+# Use noop scheduler to minimize CPU cycles
+cat > /etc/udev/rules.d/88-rax-ioscheduler.rules << EOF
+ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/scheduler}="noop"
+ACTION=="add|change", KERNEL=="xvd[a-z]", ATTR{queue/scheduler}="noop"
+EOF
+
 # simple eth0 config, again not hard-coded to the build hardware
 cat > /etc/sysconfig/network-scripts/ifcfg-eth0 << EOF
 DEVICE="eth0"

--- a/fedora_29_pvhvm.cfg
+++ b/fedora_29_pvhvm.cfg
@@ -102,6 +102,12 @@ systemctl mask tmp.mount
 # networking is handled by nova-agent
 systemctl enable NetworkManager
 
+# Use noop scheduler to minimize CPU cycles
+cat > /etc/udev/rules.d/88-rax-ioscheduler.rules << EOF
+ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/scheduler}="noop"
+ACTION=="add|change", KERNEL=="xvd[a-z]", ATTR{queue/scheduler}="noop"
+EOF
+
 # our cloud-init config
 cat > /etc/cloud/cloud.cfg.d/10_rackspace.cfg <<'EOF'
 datasource_list: [ ConfigDrive, None ]

--- a/fedora_29_pvhvm.cfg
+++ b/fedora_29_pvhvm.cfg
@@ -102,10 +102,10 @@ systemctl mask tmp.mount
 # networking is handled by nova-agent
 systemctl enable NetworkManager
 
-# Use noop scheduler to minimize CPU cycles
+# Use none scheduler to minimize CPU cycles
 cat > /etc/udev/rules.d/88-rax-ioscheduler.rules << EOF
-ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/scheduler}="noop"
-ACTION=="add|change", KERNEL=="xvd[a-z]", ATTR{queue/scheduler}="noop"
+ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/scheduler}="none"
+ACTION=="add|change", KERNEL=="xvd[a-z]", ATTR{queue/scheduler}="none"
 EOF
 
 # our cloud-init config

--- a/fedora_30_pvhvm.cfg
+++ b/fedora_30_pvhvm.cfg
@@ -77,6 +77,12 @@ libselinux-python
 
 %post --erroronfail
 
+# Use noop scheduler to minimize CPU cycles
+cat > /etc/udev/rules.d/88-rax-ioscheduler.rules << EOF
+ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/scheduler}="noop"
+ACTION=="add|change", KERNEL=="xvd[a-z]", ATTR{queue/scheduler}="noop"
+EOF
+
 # let's get rid of zeroconf
 cat > /etc/sysconfig/network << EOF
 NETWORKING=yes

--- a/fedora_30_pvhvm.cfg
+++ b/fedora_30_pvhvm.cfg
@@ -77,10 +77,10 @@ libselinux-python
 
 %post --erroronfail
 
-# Use noop scheduler to minimize CPU cycles
+# Use none scheduler to minimize CPU cycles
 cat > /etc/udev/rules.d/88-rax-ioscheduler.rules << EOF
-ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/scheduler}="noop"
-ACTION=="add|change", KERNEL=="xvd[a-z]", ATTR{queue/scheduler}="noop"
+ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/scheduler}="none"
+ACTION=="add|change", KERNEL=="xvd[a-z]", ATTR{queue/scheduler}="none"
 EOF
 
 # let's get rid of zeroconf

--- a/redhat_7_pvhvm.cfg
+++ b/redhat_7_pvhvm.cfg
@@ -156,6 +156,12 @@ echo -n > /etc/udev/rules.d/70-persistent-net.rules
 echo -n > /lib/udev/rules.d/75-persistent-net-generator.rules
 ln -s /dev/null /etc/udev/rules.d/80-net-name-slot.rules
 
+# Use noop scheduler to minimize CPU cycles
+cat > /etc/udev/rules.d/88-rax-ioscheduler.rules << EOF
+ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/scheduler}="noop"
+ACTION=="add|change", KERNEL=="xvd[a-z]", ATTR{queue/scheduler}="noop"
+EOF
+
 # simple eth0 config, again not hard-coded to the build hardware
 cat > /etc/sysconfig/network-scripts/ifcfg-eth0 << EOF
 DEVICE="eth0"

--- a/redhat_8_pvhvm.cfg
+++ b/redhat_8_pvhvm.cfg
@@ -148,6 +148,12 @@ echo -n > /etc/udev/rules.d/70-persistent-net.rules
 echo -n > /lib/udev/rules.d/75-persistent-net-generator.rules
 ln -s /dev/null /etc/udev/rules.d/80-net-name-slot.rules
 
+# Use noop scheduler to minimize CPU cycles
+cat > /etc/udev/rules.d/88-rax-ioscheduler.rules << EOF
+ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/scheduler}="noop"
+ACTION=="add|change", KERNEL=="xvd[a-z]", ATTR{queue/scheduler}="noop"
+EOF
+
 # simple eth0 config, again not hard-coded to the build hardware
 cat > /etc/sysconfig/network-scripts/ifcfg-eth0 << EOF
 DEVICE="eth0"

--- a/redhat_8_pvhvm.cfg
+++ b/redhat_8_pvhvm.cfg
@@ -148,10 +148,10 @@ echo -n > /etc/udev/rules.d/70-persistent-net.rules
 echo -n > /lib/udev/rules.d/75-persistent-net-generator.rules
 ln -s /dev/null /etc/udev/rules.d/80-net-name-slot.rules
 
-# Use noop scheduler to minimize CPU cycles
+# Use none scheduler to minimize CPU cycles
 cat > /etc/udev/rules.d/88-rax-ioscheduler.rules << EOF
-ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/scheduler}="noop"
-ACTION=="add|change", KERNEL=="xvd[a-z]", ATTR{queue/scheduler}="noop"
+ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/scheduler}="none"
+ACTION=="add|change", KERNEL=="xvd[a-z]", ATTR{queue/scheduler}="none"
 EOF
 
 # simple eth0 config, again not hard-coded to the build hardware


### PR DESCRIPTION
Based on the Red Hat IO performance webinar I attended last wk