### PR TITLE
debian_9_pvhvm_heat rotate out xen guest utilities packages

### DIFF
--- a/debian_9_pvhvm_heat.sh
+++ b/debian_9_pvhvm_heat.sh
@@ -19,7 +19,7 @@ EOF
 curl -s http://mirror.rackspace.com/ospc/public.gpg.key | sudo apt-key add -
 
 apt-get update
-apt-get install -y python3-nova-agent xe-guest-utilities
+apt-get install -y python3-nova-agent xenstore-utils
 
 # our cloud-init config
 cat > /etc/cloud/cloud.cfg.d/10_rackspace.cfg <<'EOF'


### PR DESCRIPTION
Use upstream repo packages to match monitoring and backup agents